### PR TITLE
igakit build fails due to numpy 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "numpy"]
+requires = ["setuptools", "numpy < 2.0.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def setup_package():
     from numpy.distutils.core import setup
     from numpy.distutils.core import Extension
     if 'setuptools' in sys.modules:
-        setup_args['install_requires'] = ['numpy']
+        setup_args['install_requires'] = ['numpy<2.0.0']
     setup(
         packages = ['igakit'],
         ext_modules  = [


### PR DESCRIPTION
[numpy 2.0.0](https://pypi.org/project/numpy/2.0.0/) was just released yesterday (2024-06-17) and is causing install failures on [psydac](https://github.com/pyccel/psydac/actions/runs/9549873326/job/26320488667#step:14:567). I was able to replicate this error on my Ubuntu machine, and the error points to the updated `numpy` dependency when installing `igakit`:


```sh
$ pip install igakit
Processing /home/user/igakit
Installing build dependencies ... done
Getting requirements to build wheel ... done
Installing backend dependencies ... done
Preparing metadata (pyproject.toml) ... done
Collecting numpy
Using cached numpy-2.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (19.3 MB)  # Now using numpy 2.0.0!
Building wheels for collected packages: igakit
Building wheel for igakit (pyproject.toml) ... error
error: subprocess-exited-with-error
```

The fix is to simply lock the numpy version to `numpy < 2.0.0`.